### PR TITLE
Add Django 1.7 migrations, and use django.contrib.admin.utils to support django 1.7

### DIFF
--- a/migrations/0001_initial.py
+++ b/migrations/0001_initial.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django.utils.timezone
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('contenttypes', '0002_remove_content_type_name'),
+        ('auth', '0006_require_contenttypes_0002'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='User',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('password', models.CharField(max_length=128, verbose_name='password')),
+                ('last_login', models.DateTimeField(null=True, verbose_name='last login', blank=True)),
+                ('is_superuser', models.BooleanField(default=False, help_text='Designates that this user has all permissions without explicitly assigning them.', verbose_name='superuser status')),
+                ('email', models.EmailField(unique=True, max_length=255, verbose_name='email address', db_index=True)),
+                ('is_staff', models.BooleanField(default=False, help_text='Designates whether the user can log into this admin site.', verbose_name='staff status')),
+                ('is_active', models.BooleanField(default=False, help_text='Designates whether this user should be treated as active. Unselect this instead of deleting accounts.', verbose_name='active')),
+                ('date_joined', models.DateTimeField(default=django.utils.timezone.now, verbose_name='date joined')),
+                ('groups', models.ManyToManyField(related_query_name='user', related_name='user_set', to='auth.Group', blank=True, help_text='The groups this user belongs to. A user will get all permissions granted to each of their groups.', verbose_name='groups')),
+                ('user_permissions', models.ManyToManyField(related_query_name='user', related_name='user_set', to='auth.Permission', blank=True, help_text='Specific permissions for this user.', verbose_name='user permissions')),
+                ('user_type', models.ForeignKey(editable=False, to='contenttypes.ContentType', null=True)),
+            ],
+            options={
+                'abstract': False,
+                'verbose_name': 'User',
+                'swappable': 'AUTH_USER_MODEL',
+                'verbose_name_plural': 'Users',
+            },
+        ),
+    ]

--- a/migrations/0001_initial.py
+++ b/migrations/0001_initial.py
@@ -8,8 +8,8 @@ import django.utils.timezone
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('contenttypes', '0002_remove_content_type_name'),
-        ('auth', '0006_require_contenttypes_0002'),
+        ('contenttypes', '0001_initial'),
+        ('auth', '0001_initial'),
     ]
 
     operations = [

--- a/users/admin.py
+++ b/users/admin.py
@@ -1,7 +1,12 @@
 from django.contrib import admin, messages
-from django.contrib.admin.util import model_ngettext
 from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
 from django.utils.translation import ugettext_lazy as _
+
+try:
+    from django.contrib.admin.utils import model_ngettext
+except ImportError:
+    # To support django < 1.7
+    from django.contrib.admin.util import model_ngettext
 
 from .conf import settings
 from .forms import UserChangeForm, UserCreationForm


### PR DESCRIPTION
Adding Django migrations for `Django > 1.7`.

And change import in `users.admin` module to use `django.contrib.admin.utils`
To remove deprecation warning `RemovedInDjango19Warning` in Django 1.8
