### PR TITLE
fix compatibility with Django 1.9, post_syncdb Deprecated since version 1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
     - DJANGO="Django==1.6"
     - DJANGO="Django==1.7"
     - DJANGO="Django==1.8"
+    - DJANGO="Django==1.9"
 
 matrix:
     exclude:
@@ -20,6 +21,8 @@ matrix:
           env: DJANGO="Django==1.7"
         - python: "2.6"
           env: DJANGO="Django==1.8"
+        - python: "2.6"
+          env: DJANGO="Django==1.9"
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@
 language: python
 
 python:
+  - "3.5"
+  - "3.4"
   - "3.3"
   - "2.7"
   - "2.6"
@@ -16,12 +18,29 @@ env:
 
 matrix:
     exclude:
+        # Django 1.5 support Python 2.6.5 Python 2.7, Python 3.2 and 3.3.
+        # Django 1.6 requires Python (2.6.X, 2.7.X, 3.2.X, and 3.3.X)
+        # Django 1.7 requires Python 2.7, 3.2, 3.3, or 3.4
+        # Django 1.8 requiert Python 2.7, 3.2, 3.3, 3.4 or 3.5. 
+        # Django 1.9 requiert Python 2.7, 3.4 or 3.5.
         # Python 2.6 support has been dropped for Django 1.7 onwards
+        - python: "3.4"
+          env: DJANGO="Django==1.5"
+        - python: "3.5"
+          env: DJANGO="Django==1.5"
+        - python: "3.4"
+          env: DJANGO="Django==1.6"
+        - python: "3.5"
+          env: DJANGO="Django==1.6"
         - python: "2.6"
+          env: DJANGO="Django==1.7"
+        - python: "3.5"
           env: DJANGO="Django==1.7"
         - python: "2.6"
           env: DJANGO="Django==1.8"
         - python: "2.6"
+          env: DJANGO="Django==1.9"
+        - python: "3.3"
           env: DJANGO="Django==1.9"
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors

--- a/users/utils.py
+++ b/users/utils.py
@@ -17,9 +17,9 @@ try:
 except ImportError:
     from django.contrib.sites.models import get_current_site
 
-# Deprecated since version 1.7:
+# post_syncdb Deprecated since version 1.7:
 # https://docs.djangoproject.com/en/1.8/ref/signals/#post-syncdb
-if django.VERSION >= (1, 7):
+if django.VERSION >= (1, 9):
     signals.post_syncdb = signals.post_migrate
 
 

--- a/users/utils.py
+++ b/users/utils.py
@@ -1,5 +1,5 @@
 from datetime import date
-
+import django
 from django.contrib.auth import get_user_model
 from django.core.mail import EmailMultiAlternatives
 from django.db.models import signals
@@ -16,6 +16,11 @@ try:
     from django.contrib.sites.shortcuts import get_current_site
 except ImportError:
     from django.contrib.sites.models import get_current_site
+
+# Deprecated since version 1.7:
+# https://docs.djangoproject.com/en/1.8/ref/signals/#post-syncdb
+if django.VERSION >= (1, 7):
+    signals.post_syncdb = signals.post_migrate
 
 
 if settings.USERS_CREATE_SUPERUSER:


### PR DESCRIPTION
fix compatibility with Django 1.9

in Django 1.9
```
  File "/Users/tu/workspace/django-users2/users/utils.py", line 52, in <module>
    signals.post_syncdb.connect(auto_create_superuser, sender=None)
AttributeError: 'module' object has no attribute 'post_syncdb'
```
see: https://docs.djangoproject.com/en/1.8/ref/signals/#post-syncdb