### PR TITLE
BUGFix

### DIFF
--- a/users/managers.py
+++ b/users/managers.py
@@ -40,11 +40,13 @@ class UserManager(BaseUserManager):
     def create_user(self, email, password=None, **extra_fields):
 
         is_staff = extra_fields.pop('is_staff', False)
-        return self._create_user(email, password, is_staff, False,
+        return self._create_user(email=email, password=password, 
+                                 is_staff=is_staff, is_superuser=False,
                                  **extra_fields)
 
     def create_superuser(self, email, password, **extra_fields):
-        return self._create_user(email, password, True, True,
+        return self._create_user(email=email, password=password, 
+                                 is_staff=True, is_superuser=True,
                                  is_active=True, **extra_fields)
 
 


### PR DESCRIPTION
Issue: 
function call of ``` _create_user()``` in ```create_user()``` and ```create_superuser()``` with positional args 
causes some TypeError exceptions due to evaluating arguments values twice if they exist in **extra_fields
especially: ```is_staff``` and ```is_superuser``` [ we have our own usage cases ]
 
Fix:
calling ```_create_user()``` with keyword arguments instead